### PR TITLE
fix :send-text to work faster (and at all...)

### DIFF
--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -26,8 +26,7 @@ define-command x11-send-text -docstring "send the selected text to the repl wind
     nop %sh{
         printf %s\\n "${kak_selection}" | xsel -i
         wid=$(xdotool getactivewindow)
-        xdotool search --name kak_repl_window windowactivate
-        xdotool key --clearmodifiers "Shift+Insert"
+        xdotool search --name kak_repl_window key --clearmodifiers Shift+Insert
         xdotool windowactivate $wid
     }
 }


### PR DESCRIPTION
See [discussion](https://discuss.kakoune.com/t/trying-to-run-kakoune-repl-with-st-and-dwm/1122/4) on Kakoune-message-board. xdotool windowacticate does not seem to be working with dwm, however, if we skip the activating-part it works without having to wait for a timeout.